### PR TITLE
Remove deprecated config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove unused `envSecret` values from `values.yaml`.
+
 ## [0.4.0] - 2021-12-10
 
 ### Changed

--- a/helm/starboard-app/values.yaml
+++ b/helm/starboard-app/values.yaml
@@ -5,14 +5,6 @@ starboard-app:
   image:
     repository: "quay.io/giantswarm/starboard-operator"
 
-  envSecret:
-    stringData:
-      OPERATOR_LOG_DEV_MODE: "true"
-      OPERATOR_CONCURRENT_SCAN_JOBS_LIMIT: "2"
-      OPERATOR_SCAN_JOB_RETRY_AFTER: "10m"
-      OPERATOR_BATCH_DELETE_LIMIT: "2"
-      OPERATOR_BATCH_DELETE_DELAY: "1m"
-
   rbac:
     pspEnabled: true
 


### PR DESCRIPTION
After the latest update, these aren't used anymore and have been replaced by similarly named values passed directly into the deployment

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.