### PR TITLE
Revert "Release v0.5.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] - 2022-01-24
-
 ### Changed
 
 - Update to upstream version 0.14.0 (chart version 0.9.0).
@@ -67,8 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2021-09-08
 
-[Unreleased]: https://github.com/giantswarm/starboard-app/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/giantswarm/starboard-app/compare/v0.4.0...v0.5.0
+[Unreleased]: https://github.com/giantswarm/starboard-app/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/giantswarm/starboard-app/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/giantswarm/starboard-app/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/giantswarm/starboard-app/compare/v0.3.0...v0.3.1


### PR DESCRIPTION
Reverts giantswarm/starboard-app#50

I disabled squash merging in order to do the subtree update, but the release automation relies on squash merging to create the release. I will redo the release workflow with a squash merge