### PR TITLE
Allow root for Trivy pod

### DIFF
--- a/helm/starboard-app/charts/starboard-operator/templates/podsecuritypolicy.yaml
+++ b/helm/starboard-app/charts/starboard-operator/templates/podsecuritypolicy.yaml
@@ -54,7 +54,7 @@ spec:
   hostIPC: false
   hostPID: false
   runAsUser:
-    rule: 'MustRunAsNonRoot'
+    rule: 'RunAsAny'
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:


### PR DESCRIPTION
Trivy must run as root, upstream will not support a separate PSP for scan jobs. https://github.com/aquasecurity/starboard/pull/771

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

**Important:** After this PR is tested and approved, ensure you "Squash and Merge" _unless you are updating a subtree_. The release automation in use on this repository relies on squashing, but git subtrees will be lost if squashed. This repo allows both, so you may need to change the merge type when merging.
