### PR TITLE
Set user 10000

### DIFF
--- a/helm/starboard-app/values.yaml
+++ b/helm/starboard-app/values.yaml
@@ -14,6 +14,9 @@ starboard-app:
   rbac:
     pspEnabled: true
 
+  securityContext:
+    runAsUser: 10000
+
   targetNamespaces: ""
 
   trivy:


### PR DESCRIPTION
Upstream sets `starboard` as the user and PSPs require non-root users. This avoids
`Error: container has runAsNonRoot and image has non-numeric user (starboard), cannot verify user is non-root (pod: "starboard-app-xxx", container: starboard-app)`

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

**Important:** After this PR is tested and approved, ensure you "Squash and Merge" _unless you are updating a subtree_. The release automation in use on this repository relies on squashing, but git subtrees will be lost if squashed. This repo allows both, so you may need to change the merge type when merging.
