### PR TITLE
Move our resource override to outer chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Move resource limit overrides to the App instead of modifying the upstream chart.
+
 ## [0.5.2] - 2022-02-08
 
 ### Added

--- a/helm/starboard-app/charts/starboard-operator/values.yaml
+++ b/helm/starboard-app/charts/starboard-operator/values.yaml
@@ -137,7 +137,7 @@ trivy:
       memory: 100M
     limits:
       cpu: 500m
-      memory: 1G
+      memory: 500M
 
   # githubToken is the GitHub access token used by Trivy to download the vulnerabilities
   # database from GitHub. Only applicable in Standalone mode.

--- a/helm/starboard-app/values.yaml
+++ b/helm/starboard-app/values.yaml
@@ -24,6 +24,14 @@ starboard-app:
     imageRef: quay.io/giantswarm/trivy:0.21.0
     mode: ClientServer
     serverURL: "http://trivy-app:4954"
+    # Resources for Trivy pods created by Starboard
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100M
+      limits:
+        cpu: 500m
+        memory: 1G
 
   kubeBench:
     imageRef: quay.io/giantswarm/kube-bench:0.6.3


### PR DESCRIPTION
Moves changes from https://github.com/giantswarm/starboard-app/pull/57 to our outer app instead of overriding the upstream chart directly

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

**Important:** After this PR is tested and approved, ensure you "Squash and Merge" _unless you are updating a subtree_. The release automation in use on this repository relies on squashing, but git subtrees will be lost if squashed. This repo allows both, so you may need to change the merge type when merging.
