### PR TITLE
Add seccomp to PSP when CIS Benchmarks are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added `seccomp` to the `PodSecurityPolicy` when `CISKubeBenchReports` are disabled.
+
 ## [0.8.0] - 2022-08-01
 
 ### Changed

--- a/helm/starboard-app/charts/starboard-operator/templates/podsecuritypolicy.yaml
+++ b/helm/starboard-app/charts/starboard-operator/templates/podsecuritypolicy.yaml
@@ -44,6 +44,8 @@ metadata:
   name: {{ include "starboard-operator.fullname" . }}
   labels:
     {{- include "starboard-operator.labels" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 spec:
   privileged: false
   allowPrivilegeEscalation: false


### PR DESCRIPTION
### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.

**Important:** After this PR is tested and approved, ensure you "Squash and Merge" _unless you are updating a subtree_. The release automation in use on this repository relies on squashing, but git subtrees will be lost if squashed. This repo allows both, so you may need to change the merge type when merging.
